### PR TITLE
Update license.txt copyright year to 2018

### DIFF
--- a/core/components/commerce_projectname/docs/license.txt
+++ b/core/components/commerce_projectname/docs/license.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017
+Copyright (c) 2018
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates copyright year to 2018 in core/components/commerce_projectname/docs/license.txt