### PR TITLE
Use DescriptionField in Module

### DIFF
--- a/core/components/commerce_projectname/src/Modules/Projectname.php
+++ b/core/components/commerce_projectname/src/Modules/Projectname.php
@@ -1,6 +1,7 @@
 <?php
 namespace ThirdParty\Projectname\Modules;
 use modmore\Commerce\Modules\BaseModule;
+use modmore\Commerce\Admin\Widgets\Form\DescriptionField;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 require_once dirname(dirname(__DIR__)) . '/vendor/autoload.php';

--- a/core/components/commerce_projectname/src/Modules/Projectname.php
+++ b/core/components/commerce_projectname/src/Modules/Projectname.php
@@ -45,9 +45,9 @@ class Projectname extends BaseModule {
     {
         $fields = [];
 
-//        $fields[] = new DescriptionField($this->commerce, [
-//            'description' => $this->adapter->lexicon('commerce_projectname.module_description'),
-//        ]);
+        $fields[] = new DescriptionField($this->commerce, [
+            'description' => $this->adapter->lexicon('commerce_projectname.module_description'),
+        ]);
 
         return $fields;
     }


### PR DESCRIPTION
As discussed on Slack, if you uncomment the DescriptionField in getModuleConfiguration, it will throw a class not found error. Adding the use for the DescriptionField fixes this. 

Personally, I also think it would be good to have the description field enabled by default as to give users a better clue on what the module does when enabling/disabling, so I've uncommented that. Feel free to change that though.