### PR TITLE
Update license.txt copyright year to 2019

### DIFF
--- a/core/components/commerce_projectname/docs/license.txt
+++ b/core/components/commerce_projectname/docs/license.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018
+Copyright (c) 2019
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates copyright year to 2019 in core/components/commerce_projectname/docs/license.txt