### PR TITLE
Remove Commerce version from changelog.txt

### DIFF
--- a/core/components/commerce_projectname/docs/changelog.txt
+++ b/core/components/commerce_projectname/docs/changelog.txt
@@ -1,4 +1,4 @@
-++ Projectname for Commerce 0.1.0-pl
+++ Projectname for Commerce
 ++ Released on
 ++++++++++++++++++++++++++
 - First release


### PR DESCRIPTION
Commerce version in the core/components/commerce_projectname/docs/changelog.txt file has been outdated for awhile. This PR updates this file to remove the version to make it more similar to the readme.txt file in the same docs directory.